### PR TITLE
add --no-daemon to build validation

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -23,4 +22,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build --no-daemon


### PR DESCRIPTION
**You are creating a pull request to Technototes Team 16750 and Team 20403's repository**
Hint: add `x` to the square bracket to make the checkbox checked
- [x] This Pull-Request includes global changes that may affect other users
- [ ] These feature changes have been tested on real robot and do not negatively affect existing functionality

~it's copy and paste~ inspired from https://github.com/robototes/RapidReact2022/blob/main/.github/workflows/gradle.yml and spawning daemon will cost CPU and RAM and **time** but in this use case the daemon couldn't be reused.

The best solution still be persistence build cache file