### PR TITLE
Skip spotless in Actions workflow

### DIFF
--- a/.github/workflows/gradle-lite.yml
+++ b/.github/workflows/gradle-lite.yml
@@ -21,7 +21,5 @@ jobs:
         java-version: 11
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Assemble Twenty403 with Gradle
-      run: ./gradlew :Twenty403:assembleDebug
-    - name: Assemble Sixteen750 with Gradle
-      run: ./gradlew :Sixteen750:assembleDebug
+    - name: Assemble Twenty403 and Sixteen750 with Gradle
+      run: ./gradlew justAssembleDebug --no-daemon

--- a/build.gradle
+++ b/build.gradle
@@ -46,3 +46,7 @@ spotless {
         formatAnnotations()
     }
 }
+
+task justAssembleDebug(type: GradleBuild) {
+    tasks = [':Twenty403:assembleDebug', ':Sixteen750:assembleDebug']
+}


### PR DESCRIPTION
**You are creating a pull request to Technototes Team 16750 and Team 20403's repository**
Hint: add `x` to the square bracket to make the checkbox checked
- [x] This Pull-Request includes global changes that may affect other users

Have you ever wondered when you click the green hammer in Android Studio the code `build` just fine, but when you submitted a Pull-Request the checks will be failed instantly
![image](https://user-images.githubusercontent.com/86680163/197432353-afb7fd3a-4b84-4862-afd0-ab97d13d90a5.png)

Actually when you clicked green hammer in Android Studio what happened in the background is 
![image](https://user-images.githubusercontent.com/86680163/197432608-f6c206eb-a593-4087-b8b7-203e9aed9e4c.png)

Quoting some [stackoverflow](https://stackoverflow.com/questions/44185165/what-are-the-differences-between-gradle-assemble-and-gradle-build-tasks)
> `assemble` will build your artifacts, and `build` will assemble your artifacts with additional checks.
> `build` depends on `assemble`, so build is sort of a superset of `assemble`

By just executing these specific task could skip some non-essential task that could increase the checks' speed

Why `assembleDebug` not `assemble`?
![image](https://user-images.githubusercontent.com/86680163/197433314-52c4da20-34be-4ded-9d88-151ad881b773.png)
*assembleDebug*

![image](https://user-images.githubusercontent.com/86680163/197433268-d30e19f9-e593-4fc3-8318-bbbb67cdd7d2.png)
*assemble*
