### PR TITLE
I think this should address the zeroing problem with the lift

### DIFF
--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystem/LiftSubsystem.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystem/LiftSubsystem.java
@@ -259,15 +259,15 @@ public class LiftSubsystem implements Subsystem, Supplier<Double>, Loggable {
         if (!isHardware) {
             return;
         }
-        double curLeft = leftPidController.getTargetPosition();
         ACTUAL_ZERO_LEFT = _leftMotor.get();
-        leftPidController.setTargetPosition(curLeft + ACTUAL_ZERO_LEFT);
+        leftPidController.setTargetPosition(0);
+        leftPidController.reset();
         if (singleMotor) {
             return;
         }
-        double curRight = rightPidController.getTargetPosition();
         ACTUAL_ZERO_RIGHT = _rightMotor.get();
-        rightPidController.setTargetPosition(curRight - ACTUAL_ZERO_RIGHT);
+        rightPidController.setTargetPosition(0);
+        rightPidController.reset();
     }
 
     private double getLeftPos() {


### PR DESCRIPTION
Not sure what we were thinking with the earlier code. If you hit the 'zero lift' you should probably have the lift stopped. If it's not, it's just going to move around a bit as it gets back to the new zero.
- [X] This Pull-Request includes global changes that may affect other users
- [ ] These feature changes have been tested on real robot and do not negatively affect existing functionality
