### PR TITLE
Undo the 8.1.1 SDK update until Kevin has the time to fix TechnoLib's…

### DIFF
--- a/FtcRobotController/src/main/AndroidManifest.xml
+++ b/FtcRobotController/src/main/AndroidManifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
-    android:versionCode="49"
-          android:versionName="8.1.1">
+    android:versionCode="47"
+          android:versionName="8.0">
 
   <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/ConceptExploringIMUOrientation.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/ConceptExploringIMUOrientation.java
@@ -30,6 +30,7 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
 TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
 THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
+/*
 package org.firstinspires.ftc.robotcontroller.external.samples;
 
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
@@ -41,6 +42,7 @@ import com.qualcomm.robotcore.hardware.IMU;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.AngularVelocity;
 import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
+*/
 
 /**
  * This file demonstrates the impact of setting the IMU orientation correctly or incorrectly. This
@@ -70,6 +72,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
  * The rotational velocities should follow the change in corresponding axes.
  */
 
+/*
 @TeleOp(name="Concept: IMU Orientation", group="Concept")
 @Disabled
 public class ConceptExploringIMUOrientation extends LinearOpMode {
@@ -183,3 +186,5 @@ public class ConceptExploringIMUOrientation extends LinearOpMode {
         }
     }
 }
+
+ */

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorIMUNonOrthogonal.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorIMUNonOrthogonal.java
@@ -27,6 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
 package org.firstinspires.ftc.robotcontroller.external.samples;
 
 import static com.qualcomm.hardware.rev.RevHubOrientationOnRobot.xyzOrientation;
@@ -41,6 +42,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.AngularVelocity;
 import org.firstinspires.ftc.robotcore.external.navigation.Orientation;
 import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
+*/
 
 /**
  * {@link SensorIMUNonOrthogonal} shows how to use the new universal {@link IMU} interface. This
@@ -71,6 +73,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
  * <p>
  * Finally, edit this OpMode to use at least one angle around an axis to orient your Hub.
  */
+/*
 @TeleOp(name = "Sensor: IMU Non-Orthogonal", group = "Sensor")
 @Disabled     // Comment this out to add to the OpMode list
 public class SensorIMUNonOrthogonal extends LinearOpMode
@@ -87,7 +90,7 @@ public class SensorIMUNonOrthogonal extends LinearOpMode
         // Retrieve and initialize the IMU.
         // This sample expects the IMU to be in a REV Hub and named "imu".
         imu = hardwareMap.get(IMU.class, "imu");
-
+*/
         /* Define how the hub is mounted to the robot to get the correct Yaw, Pitch and Roll values.
          *
          * You can apply up to three axis rotations to orient your Hub according to how it's mounted on the robot.
@@ -145,6 +148,7 @@ public class SensorIMUNonOrthogonal extends LinearOpMode
 
         // The next three lines define the desired axis rotations.
         // To Do: EDIT these values to match YOUR mounting configuration.
+/*
         double xRotation = 0;  // enter the desired X rotation angle here.
         double yRotation = 0;  // enter the desired Y rotation angle here.
         double zRotation = 0;  // enter the desired Z rotation angle here.
@@ -181,3 +185,4 @@ public class SensorIMUNonOrthogonal extends LinearOpMode
         }
     }
 }
+*/

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorIMUOrthogonal.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/external/samples/SensorIMUOrthogonal.java
@@ -27,6 +27,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+/*
 package org.firstinspires.ftc.robotcontroller.external.samples;
 
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot;
@@ -38,6 +39,7 @@ import com.qualcomm.robotcore.hardware.IMU;
 import org.firstinspires.ftc.robotcore.external.navigation.AngleUnit;
 import org.firstinspires.ftc.robotcore.external.navigation.AngularVelocity;
 import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
+*/
 
 /**
  * {@link SensorIMUOrthogonal} shows how to use the new universal {@link IMU} interface. This
@@ -77,6 +79,7 @@ import org.firstinspires.ftc.robotcore.external.navigation.YawPitchRollAngles;
  * Finally, choose the two correct parameters to define how your Hub is mounted and edit this OpMode
  * to use those parameters.
  */
+/*
 @TeleOp(name = "Sensor: IMU Orthogonal", group = "Sensor")
 @Disabled   // Comment this out to add to the OpMode list
 public class SensorIMUOrthogonal extends LinearOpMode
@@ -107,6 +110,7 @@ public class SensorIMUOrthogonal extends LinearOpMode
          *
          * To Do:  EDIT these two lines to match YOUR mounting configuration.
          */
+/*
         RevHubOrientationOnRobot.LogoFacingDirection logoDirection = RevHubOrientationOnRobot.LogoFacingDirection.UP;
         RevHubOrientationOnRobot.UsbFacingDirection  usbDirection  = RevHubOrientationOnRobot.UsbFacingDirection.FORWARD;
 
@@ -143,3 +147,4 @@ public class SensorIMUOrthogonal extends LinearOpMode
         }
     }
 }
+*/

--- a/build.dependencies.gradle
+++ b/build.dependencies.gradle
@@ -25,14 +25,14 @@ repositories {
 // Removed the TensorFlow dependencies, cuz we're not using it
 // Would be nice if group these dependencies by author/developer
 dependencies {
-    implementation 'org.firstinspires.ftc:Inspection:8.1.1'
-    implementation 'org.firstinspires.ftc:Blocks:8.1.1'
-    // implementation 'org.firstinspires.ftc:Tfod:8.1.1'
-    implementation 'org.firstinspires.ftc:RobotCore:8.1.1'
-    implementation 'org.firstinspires.ftc:RobotServer:8.1.1'
-    implementation 'org.firstinspires.ftc:OnBotJava:8.1.1'
-    implementation 'org.firstinspires.ftc:Hardware:8.1.1'
-    implementation 'org.firstinspires.ftc:FtcCommon:8.1.1'
+    implementation 'org.firstinspires.ftc:Inspection:8.0.0'
+    implementation 'org.firstinspires.ftc:Blocks:8.0.0'
+    // implementation 'org.firstinspires.ftc:Tfod:8.0.0'
+    implementation 'org.firstinspires.ftc:RobotCore:8.0.0'
+    implementation 'org.firstinspires.ftc:RobotServer:8.0.0'
+    implementation 'org.firstinspires.ftc:OnBotJava:8.0.0'
+    implementation 'org.firstinspires.ftc:Hardware:8.0.0'
+    implementation 'org.firstinspires.ftc:FtcCommon:8.0.0'
     // implementation 'org.tensorflow:tensorflow-lite-task-vision:0.2.0'
 		implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'org.firstinspires.ftc:gameAssets-PowerPlay:1.0.0'


### PR DESCRIPTION
… IMU stuff
- [X] This Pull-Request includes global changes that may affect other users
- [ ] These feature changes have been tested on real robot and do not negatively affect existing functionality

I forgot to test TechnoLib's driving stuff with the 8.1.1 SDK. Turns out, it's doing some complex configuration stuff with the IMU. I don't want to risk it with InterLeague's 8 days away, so I'm just rolling back the 8.1.1 changes.