### PR TITLE
PID tuning and switch 20403 to *velocity* based driving

### DIFF
--- a/Swerveteen750/src/main/java/org/firstinspires/ftc/swerveteen750/opmode/diagnosis/SwervePodVelocityPIDTuner.java
+++ b/Swerveteen750/src/main/java/org/firstinspires/ftc/swerveteen750/opmode/diagnosis/SwervePodVelocityPIDTuner.java
@@ -1,2 +1,134 @@
-package org.firstinspires.ftc.swerveteen750.subsystem.drive;public class SwervePodVelocityPIDTuner {
+package org.firstinspires.ftc.swerveteen750.opmode.diagnosis;
+
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.MAX_ACCEL;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.MAX_VEL;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.MOTOR_VELO_PID_UNIVERSAL;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.RUN_USING_ENCODER;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.kV;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.roadrunner.profile.MotionProfile;
+import com.acmerobotics.roadrunner.profile.MotionProfileGenerator;
+import com.acmerobotics.roadrunner.profile.MotionState;
+import com.acmerobotics.roadrunner.util.NanoClock;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.RobotLog;
+
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.swerveteen750.subsystem.drive.SwerveDriveForVelocityTuning;
+
+import java.util.List;
+
+/*
+ * This routine is designed to tune the PID coefficients used by the REV Expansion Hubs for closed-
+ * loop velocity control. Although it may seem unnecessary, tuning these coefficients is just as
+ * important as the positional parameters. Like the other manual tuning routines, this op mode
+ * relies heavily upon the dashboard. To access the dashboard, connect your computer to the RC's
+ * WiFi network. In your browser, navigate to https://192.168.49.1:8080/dash if you're using the RC
+ * phone or https://192.168.43.1:8080/dash if you are using the Control Hub. Once you've successfully
+ * connected, start the program, and your robot will begin moving forward and backward according to
+ * a motion profile. Your job is to graph the velocity errors over time and adjust the PID
+ * coefficients (note: the tuning variable will not appear until the op mode finishes initializing).
+ * Once you've found a satisfactory set of gains, add them to the DriveConstants.java file under the
+ * MOTOR_VELO_PID field.
+ *
+ * Recommended tuning process:
+ *
+ * 1. Increase kP until any phase lag is eliminated. Concurrently increase kD as necessary to
+ *    mitigate oscillations.
+ * 2. Add kI (or adjust kF) until the steady state/constant velocity plateaus are reached.
+ * 3. Back off kP and kD a little until the response is less oscillatory (but without lag).
+ *
+ * Pressing Y/Δ (Xbox/PS4) will pause the tuning process and enter driver override, allowing the
+ * user to reset the position of the bot in the event that it drifts off the path.
+ * Pressing B/O (Xbox/PS4) will cede control back to the tuning process.
+ */
+@Config
+@Autonomous(group = "drive")
+public class SwervePodVelocityPIDTuner extends LinearOpMode {
+    public static double DISTANCE = 72; // in
+
+    private static MotionProfile generateProfile(boolean movingForward) {
+        MotionState start = new MotionState(movingForward ? 0 : DISTANCE, 0, 0, 0);
+        MotionState goal = new MotionState(movingForward ? DISTANCE : 0, 0, 0, 0);
+        return MotionProfileGenerator.generateSimpleMotionProfile(start, goal, MAX_VEL, MAX_ACCEL);
+    }
+
+    @Override
+    public void runOpMode() {
+        if (!RUN_USING_ENCODER) {
+            RobotLog.setGlobalErrorMsg("%s does not need to be run if the built-in motor velocity" +
+                    "PID is not in use", getClass().getSimpleName());
+        }
+
+        Telemetry telemetry = new MultipleTelemetry(this.telemetry, FtcDashboard.getInstance().getTelemetry());
+
+        SwerveDriveForVelocityTuning drive = new SwerveDriveForVelocityTuning(hardwareMap);
+
+        double lastKp = MOTOR_VELO_PID_UNIVERSAL.p;
+        double lastKi = MOTOR_VELO_PID_UNIVERSAL.i;
+        double lastKd = MOTOR_VELO_PID_UNIVERSAL.d;
+        double lastKf = MOTOR_VELO_PID_UNIVERSAL.f;
+
+        drive.setAllMotorPIDFCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID_UNIVERSAL);
+
+        NanoClock clock = NanoClock.system();
+
+        telemetry.addLine("Ready!");
+        telemetry.update();
+        telemetry.clearAll();
+
+        waitForStart();
+
+        if (isStopRequested()) return;
+
+        boolean movingForwards = true;
+        MotionProfile activeProfile = generateProfile(true);
+        double profileStart = clock.seconds();
+
+
+        while (!isStopRequested()) {
+            // calculate and set the motor power
+            double profileTime = clock.seconds() - profileStart;
+
+            if (profileTime > activeProfile.duration()) {
+                // generate a new profile
+                movingForwards = !movingForwards;
+                activeProfile = generateProfile(movingForwards);
+                profileStart = clock.seconds();
+            }
+
+            MotionState motionState = activeProfile.get(profileTime);
+            double targetPower = kV * motionState.getV();
+            drive.setMotorPowers(targetPower, targetPower, targetPower, targetPower);
+
+            List<Double> velocities = drive.getWheelVelocities();
+
+            // update telemetry
+            telemetry.addData("targetVelocity", motionState.getV());
+            for (int i = 0; i < velocities.size(); i++) {
+                telemetry.addData("measuredVelocity" + i, velocities.get(i));
+                telemetry.addData(
+                        "error" + i,
+                        motionState.getV() - velocities.get(i)
+                );
+            }
+
+            if (lastKp != MOTOR_VELO_PID_UNIVERSAL.p || lastKd != MOTOR_VELO_PID_UNIVERSAL.d
+                    || lastKi != MOTOR_VELO_PID_UNIVERSAL.i || lastKf != MOTOR_VELO_PID_UNIVERSAL.f) {
+                drive.setAllMotorPIDFCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID_UNIVERSAL);
+
+                lastKp = MOTOR_VELO_PID_UNIVERSAL.p;
+                lastKi = MOTOR_VELO_PID_UNIVERSAL.i;
+                lastKd = MOTOR_VELO_PID_UNIVERSAL.d;
+                lastKf = MOTOR_VELO_PID_UNIVERSAL.f;
+            }
+
+            telemetry.update();
+        }
+    }
 }

--- a/Swerveteen750/src/main/java/org/firstinspires/ftc/swerveteen750/subsystem/drive/SwerveDriveForVelocityTuning.java
+++ b/Swerveteen750/src/main/java/org/firstinspires/ftc/swerveteen750/subsystem/drive/SwerveDriveForVelocityTuning.java
@@ -1,2 +1,116 @@
-package org.firstinspires.ftc.swerveteen750.subsystem.drive;public class SwerveDriveForVelocityTuning {
+package org.firstinspires.ftc.swerveteen750.subsystem.drive;
+
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.MOTOR_VELO_PID_UNIVERSAL;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.RUN_USING_ENCODER;
+import static org.firstinspires.ftc.swerveteen750.subsystem.drive.DriveConstantsForPidTuner.encoderTicksToInches;
+
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.roadrunner.control.PIDCoefficients;
+import com.qualcomm.hardware.lynx.LynxModule;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorEx;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+import com.qualcomm.robotcore.hardware.PIDFCoefficients;
+import com.qualcomm.robotcore.hardware.VoltageSensor;
+import com.qualcomm.robotcore.hardware.configuration.typecontainers.MotorConfigurationType;
+
+
+import org.firstinspires.ftc.swerveteen750.swerve_util.LynxModuleUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/*
+ * Simple mecanum drive hardware implementation for REV hardware.
+ */
+@Config
+public class SwerveDriveForVelocityTuning {
+    public static PIDCoefficients TRANSLATIONAL_PID = new PIDCoefficients(0, 0, 0);
+    public static PIDCoefficients HEADING_PID = new PIDCoefficients(0, 0, 0);
+
+    public static double LATERAL_MULTIPLIER = 1;
+
+    public static double VX_WEIGHT = 1;
+    public static double VY_WEIGHT = 1;
+    public static double OMEGA_WEIGHT = 1;
+
+    private final DcMotorEx leftFront, leftRear, rightRear, rightFront;
+    private final List<DcMotorEx> motors;
+
+    private final VoltageSensor batteryVoltageSensor;
+
+    public SwerveDriveForVelocityTuning(HardwareMap hardwareMap) {
+        LynxModuleUtil.ensureMinimumFirmwareVersion(hardwareMap);
+
+        batteryVoltageSensor = hardwareMap.voltageSensor.iterator().next();
+
+        for (LynxModule module : hardwareMap.getAll(LynxModule.class)) {
+            module.setBulkCachingMode(LynxModule.BulkCachingMode.AUTO);
+        }
+
+        leftFront = hardwareMap.get(DcMotorEx.class, "leftFrontMotor");
+        leftRear = hardwareMap.get(DcMotorEx.class, "leftRearMotor");
+        rightRear = hardwareMap.get(DcMotorEx.class, "rightRearMotor");
+        rightFront = hardwareMap.get(DcMotorEx.class, "rightFrontMotor");
+
+        motors = Arrays.asList(leftFront, leftRear, rightRear, rightFront);
+
+        for (DcMotorEx motor : motors) {
+            MotorConfigurationType motorConfigurationType = motor.getMotorType().clone();
+            motorConfigurationType.setAchieveableMaxRPMFraction(1.0);
+            motor.setMotorType(motorConfigurationType);
+        }
+
+        if (RUN_USING_ENCODER) {
+            setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        }
+
+        setZeroPowerBehavior(DcMotor.ZeroPowerBehavior.BRAKE);
+
+        if (RUN_USING_ENCODER && MOTOR_VELO_PID_UNIVERSAL != null) {
+            setAllMotorPIDFCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID_UNIVERSAL);
+        }
+
+        // TODO: reverse any motors using DcMotor.setDirection()
+
+    }
+
+    public void setMode(DcMotor.RunMode runMode) {
+        for (DcMotorEx motor : motors) {
+            motor.setMode(runMode);
+        }
+    }
+
+    public void setZeroPowerBehavior(DcMotor.ZeroPowerBehavior zeroPowerBehavior) {
+        for (DcMotorEx motor : motors) {
+            motor.setZeroPowerBehavior(zeroPowerBehavior);
+        }
+    }
+
+    public void setAllMotorPIDFCoefficients(DcMotor.RunMode runMode, PIDFCoefficients coefficients) {
+        PIDFCoefficients compensatedCoefficients = new PIDFCoefficients(
+                coefficients.p, coefficients.i, coefficients.d,
+                coefficients.f * 12 / batteryVoltageSensor.getVoltage()
+        );
+
+        for (DcMotorEx motor : motors) {
+            motor.setPIDFCoefficients(runMode, compensatedCoefficients);
+        }
+    }
+
+    public List<Double> getWheelVelocities() {
+        List<Double> wheelVelocities = new ArrayList<>();
+        for (DcMotorEx motor : motors) {
+            wheelVelocities.add(encoderTicksToInches(motor.getVelocity()));
+        }
+        return wheelVelocities;
+    }
+
+    public void setMotorPowers(double v, double v1, double v2, double v3) {
+        leftFront.setPower(v);
+        leftRear.setPower(v1);
+        rightRear.setPower(v2);
+        rightFront.setPower(v3);
+    }
 }

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/opmode/testing/DriveVelocityPIDTuner.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/opmode/testing/DriveVelocityPIDTuner.java
@@ -1,3 +1,186 @@
 package org.firstinspires.ftc.twenty403.opmode.testing;
 
-public class DriveVelocityPIDTuner {}
+import static org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem.DriveConstants.MAX_ACCEL;
+import static org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem.DriveConstants.MAX_VEL;
+import static org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem.DriveConstants.MOTOR_VELO_PID;
+import static org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem.DriveConstants.RUN_USING_ENCODER;
+import static org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem.DriveConstants.kV;
+
+import com.acmerobotics.dashboard.FtcDashboard;
+import com.acmerobotics.dashboard.config.Config;
+import com.acmerobotics.dashboard.telemetry.MultipleTelemetry;
+import com.acmerobotics.roadrunner.geometry.Pose2d;
+import com.acmerobotics.roadrunner.profile.MotionProfile;
+import com.acmerobotics.roadrunner.profile.MotionProfileGenerator;
+import com.acmerobotics.roadrunner.profile.MotionState;
+import com.acmerobotics.roadrunner.util.NanoClock;
+import com.qualcomm.robotcore.eventloop.opmode.Autonomous;
+import com.qualcomm.robotcore.eventloop.opmode.LinearOpMode;
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.util.RobotLog;
+import com.technototes.library.hardware2.HardwareBuilder;
+import java.util.List;
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+import org.firstinspires.ftc.twenty403.Hardware;
+import org.firstinspires.ftc.twenty403.subsystem.DrivebaseSubsystem;
+
+/*
+ * This routine is designed to tune the PID coefficients used by the REV Expansion Hubs for closed-
+ * loop velocity control. Although it may seem unnecessary, tuning these coefficients is just as
+ * important as the positional parameters. Like the other manual tuning routines, this op mode
+ * relies heavily upon the dashboard. To access the dashboard, connect your computer to the RC's
+ * WiFi network. In your browser, navigate to https://192.168.49.1:8080/dash if you're using the RC
+ * phone or https://192.168.43.1:8080/dash if you are using the Control Hub. Once you've successfully
+ * connected, start the program, and your robot will begin moving forward and backward according to
+ * a motion profile. Your job is to graph the velocity errors over time and adjust the PID
+ * coefficients (note: the tuning variable will not appear until the op mode finishes initializing).
+ * Once you've found a satisfactory set of gains, add them to the DriveConstants.java file under the
+ * MOTOR_VELO_PID field.
+ *
+ * Recommended tuning process:
+ *
+ * 1. Increase kP until any phase lag is eliminated. Concurrently increase kD as necessary to
+ *    mitigate oscillations.
+ * 2. Add kI (or adjust kF) until the steady state/constant velocity plateaus are reached.
+ * 3. Back off kP and kD a little until the response is less oscillatory (but without lag).
+ *
+ * Pressing Y/Δ (Xbox/PS4) will pause the tuning process and enter driver override, allowing the
+ * user to reset the position of the bot in the event that it drifts off the path.
+ * Pressing B/O (Xbox/PS4) will cede control back to the tuning process.
+ */
+@Config
+@Autonomous(name = "RR PID Tuner")
+public class DriveVelocityPIDTuner extends LinearOpMode {
+
+    public static double DISTANCE = 28; // in
+
+    enum Mode {
+        DRIVER_MODE,
+        TUNING_MODE,
+    }
+
+    private static MotionProfile generateProfile(boolean movingForward) {
+        MotionState start = new MotionState(movingForward ? 0 : DISTANCE, 0, 0, 0);
+        MotionState goal = new MotionState(movingForward ? DISTANCE : 0, 0, 0, 0);
+        return MotionProfileGenerator.generateSimpleMotionProfile(start, goal, MAX_VEL, MAX_ACCEL);
+    }
+
+    @Override
+    public void runOpMode() {
+        if (!RUN_USING_ENCODER) {
+            RobotLog.setGlobalErrorMsg(
+                "%s does not need to be run if the built-in motor velocity" + "PID is not in use",
+                getClass().getSimpleName()
+            );
+        }
+
+        Telemetry telemetry = new MultipleTelemetry(
+            this.telemetry,
+            FtcDashboard.getInstance().getTelemetry()
+        );
+        // A little TechnoLib silliness:
+        HardwareBuilder.initMap(hardwareMap);
+        Hardware hw = new Hardware(hardwareMap);
+        DrivebaseSubsystem drive = new DrivebaseSubsystem(
+            hw.flDriveMotor,
+            hw.frDriveMotor,
+            hw.rlDriveMotor,
+            hw.rrDriveMotor,
+            hw.imu,
+            null
+        );
+
+        Mode mode = Mode.TUNING_MODE;
+
+        double lastKp = MOTOR_VELO_PID.p;
+        double lastKi = MOTOR_VELO_PID.i;
+        double lastKd = MOTOR_VELO_PID.d;
+        double lastKf = MOTOR_VELO_PID.f;
+
+        drive.setPIDFCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID);
+
+        NanoClock clock = NanoClock.system();
+
+        telemetry.addLine("Ready!");
+        telemetry.update();
+        telemetry.clearAll();
+
+        waitForStart();
+
+        if (isStopRequested()) return;
+
+        boolean movingForwards = true;
+        MotionProfile activeProfile = generateProfile(true);
+        double profileStart = clock.seconds();
+
+        while (!isStopRequested()) {
+            telemetry.addData("mode", mode);
+
+            switch (mode) {
+                case TUNING_MODE:
+                    if (gamepad1.y) {
+                        mode = Mode.DRIVER_MODE;
+                        drive.setMode(DcMotor.RunMode.RUN_WITHOUT_ENCODER);
+                    }
+
+                    // calculate and set the motor power
+                    double profileTime = clock.seconds() - profileStart;
+
+                    if (profileTime > activeProfile.duration()) {
+                        // generate a new profile
+                        movingForwards = !movingForwards;
+                        activeProfile = generateProfile(movingForwards);
+                        profileStart = clock.seconds();
+                    }
+
+                    MotionState motionState = activeProfile.get(profileTime);
+                    double targetPower = kV * motionState.getV();
+                    drive.setDrivePower(new Pose2d(targetPower, 0, 0));
+
+                    List<Double> velocities = drive.getWheelVelocities();
+
+                    // update telemetry
+                    telemetry.addData("targetVelocity", motionState.getV());
+                    for (int i = 0; i < velocities.size(); i++) {
+                        telemetry.addData("measuredVelocity" + i, velocities.get(i));
+                        telemetry.addData("error" + i, motionState.getV() - velocities.get(i));
+                    }
+                    break;
+                case DRIVER_MODE:
+                    if (gamepad1.b) {
+                        drive.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
+                        mode = Mode.TUNING_MODE;
+                        movingForwards = true;
+                        activeProfile = generateProfile(movingForwards);
+                        profileStart = clock.seconds();
+                    }
+
+                    drive.setWeightedDrivePower(
+                        new Pose2d(
+                            -gamepad1.left_stick_y,
+                            -gamepad1.left_stick_x,
+                            -gamepad1.right_stick_x
+                        )
+                    );
+                    break;
+            }
+
+            if (
+                lastKp != MOTOR_VELO_PID.p ||
+                lastKd != MOTOR_VELO_PID.d ||
+                lastKi != MOTOR_VELO_PID.i ||
+                lastKf != MOTOR_VELO_PID.f
+            ) {
+                drive.setPIDFCoefficients(DcMotor.RunMode.RUN_USING_ENCODER, MOTOR_VELO_PID);
+
+                lastKp = MOTOR_VELO_PID.p;
+                lastKi = MOTOR_VELO_PID.i;
+                lastKd = MOTOR_VELO_PID.d;
+                lastKf = MOTOR_VELO_PID.f;
+            }
+
+            telemetry.update();
+        }
+    }
+}

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystem/DrivebaseSubsystem.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystem/DrivebaseSubsystem.java
@@ -31,6 +31,8 @@ public class DrivebaseSubsystem
     @Config
     public abstract static class DriveConstants implements MecanumConstants {
 
+        public static double VEL_SCALE = 5.0;
+
         public static double SLOW_MOTOR_SPEED = 0.6;
         public static double FAST_MOTOR_SPEED = 1.0;
         public static double AUTO_MOTOR_SPEED = 0.9;
@@ -46,9 +48,9 @@ public class DrivebaseSubsystem
 
         @MotorVeloPID
         public static PIDFCoefficients MOTOR_VELO_PID = new PIDFCoefficients(
-            20,
+            18,
             0,
-            3,
+            1,
             MecanumConstants.getMotorVelocityF(MAX_RPM / 60 * TICKS_PER_REV)
         );
 
@@ -156,7 +158,7 @@ public class DrivebaseSubsystem
         speed = DriveConstants.SLOW_MOTOR_SPEED;
         odometry = odo;
 
-        if (this.getLocalizer() != null) {
+        if (this.getLocalizer() != null && odo != null) {
             this.setLocalizer(new OverrideLocalizer(this.getLocalizer(), odo, this));
             locState = "created";
         } else {
@@ -197,10 +199,17 @@ public class DrivebaseSubsystem
 
     @Override
     public void setMotorPowers(double v, double v1, double v2, double v3) {
+        leftFront.setVelocity(v * DriveConstants.VEL_SCALE, AngleUnit.RADIANS);
+        leftRear.setVelocity(v1 * DriveConstants.VEL_SCALE, AngleUnit.RADIANS);
+        rightRear.setVelocity(v2 * DriveConstants.VEL_SCALE, AngleUnit.RADIANS);
+        rightFront.setVelocity(v3 * DriveConstants.VEL_SCALE, AngleUnit.RADIANS);
+        /*
         leftFront.setPower(v * DriveConstants.AFL_SCALE);
         leftRear.setPower(v1 * DriveConstants.ARL_SCALE);
         rightRear.setPower(v2 * DriveConstants.ARR_SCALE);
         rightFront.setPower(v3 * DriveConstants.AFR_SCALE);
+
+ */
     }
 
     // Stuff below is used for tele-op trajectory motion


### PR DESCRIPTION
- [ ] This Pull-Request includes global changes that may affect other users
- [ ] These feature changes have been tested on real robot and do not negatively affect existing functionality

This is a very targeted change to switch from power to velocity based drive, which results in the robot driving pretty much in a straight line, but it still rotates slowly.

It also includes the Velocity PID tuner for both 20403 and the swerve base.